### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/apps/express-ts-server/src/utils/sanitizer.ts
+++ b/apps/express-ts-server/src/utils/sanitizer.ts
@@ -30,7 +30,7 @@ class Sanitizer {
    */
   private static _sanitize(value: unknown, _visitedObjects: WeakSet<object>): unknown {
     if (typeof value === "string") {
-      return value.replace(/[*+?^${}()|[\]]/g, "\\$&");
+      return value.replace(/[*+?^${}()|[\]\\]/g, "\\$&");
     } else if (Array.isArray(value)) {
       return value.map((e) => this._sanitize(e, _visitedObjects));
     } else if (value && typeof value === "object") {


### PR DESCRIPTION
Potential fix for [https://github.com/caganseyrek/ts-express-next/security/code-scanning/1](https://github.com/caganseyrek/ts-express-next/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes are also escaped in the `_sanitize` method. This can be done by modifying the regular expression used in the `replace` method to include backslashes. The updated regular expression should escape all instances of the characters `*+?^${}()|[\]` and backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
